### PR TITLE
Fix format & lint commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint \"./**/*.{js,jsx}\"",
-    "lint:fix": "eslint \"./**/*.{js,jsx}\" --fix",
-    "format": "prettier \"./**/*.{js,jsx}\" --write",
-    "format:check": "prettier \"./**/*.{js,jsx}\" -l"
+    "lint": "eslint \"./**/*.{js,jsx,ts,tsx}\"",
+    "lint:fix": "eslint \"./**/*.{js,jsx,ts,tsx}\" --fix",
+    "format": "prettier \"./**/*.{js,jsx,ts,tsx}\" --write",
+    "format:check": "prettier \"./**/*.{js,jsx,ts,tsx}\" -l"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^8.19.1",
@@ -41,7 +41,7 @@
     }
   },
 	"lint-staged": {
-    "*.{js,jsx}": ["eslint"],
-    "*.{js,jsx,css}": ["prettier --write"]
+    "*.{js,jsx,ts,tsx}": ["eslint"],
+    "*.{js,jsx,css,ts,tsx}": ["prettier --write"]
   }
 }


### PR DESCRIPTION
prettier and eslint didn't run on .ts and .tsx files, so I added those. I did not run `npm run format` on the whole codebase after fixing this just to avoid any painful merge conflicts.