### PR TITLE
Add banner variant

### DIFF
--- a/src/components/BogBanner/BogBanner.tsx
+++ b/src/components/BogBanner/BogBanner.tsx
@@ -10,9 +10,9 @@ export type BannerType =
   | 'warning'
   | 'message'
   | 'brand-message';
-export type BannerTone = 'filled' | 'outlined';
+export type BannerVariant = 'filled' | 'surface' | 'outlined';
 export type BogBannerType = BannerType;
-export type BogBannerTone = BannerTone;
+export type BogBannerVariant = BannerVariant;
 type BogIconLikeProps = React.ComponentProps<typeof BogIcon>;
 
 export interface BogBannerProps
@@ -21,7 +21,7 @@ export interface BogBannerProps
     'variant' | 'content'
   > {
   type: BannerType;
-  tone?: BannerTone;
+  variant?: BannerVariant;
   iconProps?: BogIconLikeProps;
   content: React.ReactElement;
   className?: string;
@@ -53,7 +53,7 @@ function defaultIconFor(type: BannerType): BogIconLikeProps['name'] {
 
 export default function BogBanner({
   type,
-  tone = 'filled',
+  variant = 'filled',
   iconProps,
   content,
   className,
@@ -65,7 +65,7 @@ export default function BogBanner({
   const rootClass = clsx(
     styles.root,
     TYPE_CLASS[type],
-    styles[tone],
+    styles[variant],
     className,
   );
 
@@ -74,7 +74,7 @@ export default function BogBanner({
 
   const baseName = iconProps?.name ?? defaultIconFor(type);
   const forcedWeight =
-    iconProps?.weight ?? (tone === 'filled' ? 'fill' : 'regular');
+    iconProps?.weight ?? (variant === 'filled' ? 'fill' : 'regular');
 
   const iconNode = (
     <BogIcon

--- a/src/components/BogBanner/styles.module.css
+++ b/src/components/BogBanner/styles.module.css
@@ -27,6 +27,7 @@
   z-index: 0;
 }
 .outlined::before { content: none; }
+.surface::before { content: none; }
 
 .inner {
   position: relative;
@@ -60,6 +61,13 @@
   border-color: var(--bor-outlined, var(--color-accent, #FC5B43));
 }
 .outlined .icon { color: currentColor; }
+
+.surface {
+  background: color-mix(in srgb, var(--bg-filled, var(--color-accent, #FC5B43)) 5%, transparent);
+  color: var(--fg-outlined, var(--color-accent, #FC5B43));
+  border-color: var(--bor-outlined, var(--color-accent, #FC5B43));
+}
+.surface .icon { color: currentColor; }
 
 .error {
   --rail: var(--color-error, #C73A3A);

--- a/src/stories/BogBanner.stories.tsx
+++ b/src/stories/BogBanner.stories.tsx
@@ -25,9 +25,9 @@ const meta: Meta<typeof BogBanner> = {
       options: ['message', 'success', 'warning', 'error', 'brand-message'],
       description: 'Semantic style',
     },
-    tone: {
+    variant: {
       control: 'inline-radio',
-      options: ['filled', 'outlined'],
+      options: ['filled', 'surface', 'outlined'],
       description: 'Visual style',
     },
     iconProps: {
@@ -47,7 +47,7 @@ type Story = StoryObj<typeof meta>;
 export const Banner: Story = {
   args: {
     type: 'message',
-    tone: 'filled',
+    variant: 'filled',
     iconProps: { name: 'info' },
     content: <span>This is the description.</span>,
   },


### PR DESCRIPTION
Addresses #89. Surface background color is 5% transparency version of filled background color, following the figma